### PR TITLE
Bump JupyterHub version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,20 +133,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# EKS related 
-cluster/*
-*.lock
-test/*
-IAM/*
-TLDR.gif
-
-
-scripts/*
-illumidesk/charts/
-illumidesk/kots/*
-illumidesk/kots/deps
-illumidesk/kots/manifests/*.tgz
-illumidesk/.helmignore
-test/
-kots/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,16 @@ For example:
 hostAliases: []
 ```
 
+## Dependency Updates
+
+This setup uses a standard helm chart lock file `Chart.lock` to freeze dependencies (sub-charts). To update the `Chart.lock` file after updating a depency run the following command to update the `Chart.lock` file as well:
+
+```bash
+helm dependency update
+```
+
+> **NOTE**: you may have to run the above command with `sudo` since a temporary folder is created during the update process.
+
 ### PR Approval and Release Process
 
 1. Changes are automatically linted and tested using the [`ct` tool](https://github.com/helm/chart-testing) as a [GitHub action](https://github.com/helm/chart-testing-action). Those tests are based on `helm install`, `helm lint` and `helm test` commands and provide quick feedback about the changes in the PR. For those tests, the chart is installed on top of [kind](https://github.com/kubernetes-sigs/kind) and this step is not blocking (as opposed to 3rd step).

--- a/charts/illumidesk/Chart.lock
+++ b/charts/illumidesk/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: jupyterhub
+  repository: https://jupyterhub.github.io/helm-chart/
+  version: 0.11.1
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.1.3
+- name: datadog
+  repository: https://helm.datadoghq.com
+  version: 2.4.29
+digest: sha256:11b6512647756e783dfa1b9befb5d7ec6b9a2e6537e8cf3fd6bf677648aa5900
+generated: "2021-02-26T15:56:48.4961567-05:00"

--- a/charts/illumidesk/Chart.yaml
+++ b/charts/illumidesk/Chart.yaml
@@ -6,7 +6,7 @@ description: An extention of the JupyterHub chart with additional IllumiDesk res
 icon: https://configs.illumidesk.com/images/illumidesk-80.png
 dependencies:
   - name: jupyterhub
-    version: "0.9.1"
+    version: "0.11.1"
     repository: https://jupyterhub.github.io/helm-chart/
     import-values:
       - child: rbac


### PR DESCRIPTION
- Updates JupyterHub version to [0.11.1](https://jupyterhub.github.io/helm-chart/)

Closes #42 