### PR TITLE
Clarify instructions to lint the chart(s) locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,24 +66,32 @@ helm dependency build
 3. Once the changes are accepted, the PR is tested (if needed) into the IllumiDesk CI pipeline, the chart is installed and tested (verification and functional tests) on top of different k8s platforms.
 4. When the PR passes all tests, the PR is merged by the reviewer(s) in the GitHub `main` branch.
 
-### Tips and Tricks
+### Run the linter locally (ct lint)
 
-You can use the `quay.io/helmpack/chart-testing:latest` image to run `ct` commands before creating a Pull Request. Use the following command to run the ct-lint job, for example:
+This setup uses the `ct` utility to lint the helm chart with GitHub Actions. You can use the `quay.io/helmpack/chart-testing:latest` image to run `ct` commands and lint the chart(s) before creating a Pull Request. To run the `ct lint ...` command from your local environment follow the steps below:
+
+1. From the **root** of this repo start the container that includes all required dependencies:
 
 ```bash
-docker run --rm -ti -v $(pwd):/workdir --workdir /workdir --detach --network host --name ct quay.io/helmpack/chart-testing:latest sh
+docker run --rm -ti -v $(pwd):/workdir --workdir /workdir --network host --name ct quay.io/helmpack/chart-testing:latest sh
 ```
 
-Then, from the command prompt, enter:
+2. (Optional) Install the sub-charts that are included with this chart as dependencies:
+
+```bash
+ct install --config .github/ct.yaml
+```
+
+3. Run the linter with `ct`:
 
 ```bash
 ct lint --config .github/ct.yaml
 ```
 
-These command will:
+These steps help emulate the existing GitHub Action that runs the `ct lint` command. Specifically, these commands will:
 
-- Run the `ct` container that includes all required dependencies
-- Mount the current location to a `/workdir` path within the container
-- Name the running container as `ct`
-- Run the container in detached mode
-- Run the `ct lint` command as it runs with the GitHub action specification
+- Run the `ct` container that includes all required dependencies.
+- Mount the current location to a `/workdir` path within the container.
+- Name the running container as `ct`.
+- (Optional) Install all sub-chart dependencies with `ct`.
+- Run the `ct lint` command as it runs with the GitHub action specification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,12 +104,6 @@ When squashing and merging to the `main` branch, use the following format to pro
 
 - `Merge Description` should initiate with a capital letter, as it provides the changelog with a standard sentence structure.
 
-- `Scope` is used to define what is being updated. Our current scopes include:
-
-1. core
-3. grader
-4. workspace
-
 - `Commit Types` are listed below:
 
 | Commit Type | Commit Format |
@@ -127,19 +121,19 @@ Examples:
 - Commit a new feature:
 
     ```
-    feat(workspace): Publish static notebooks with live widgets
+    feat: Adds external database option
     ```
 
 - Commit a bug fix:
 
     ```
-    fix(core): Allow students to open submitted assignments from grades section
+    fix: Updates template to enable ingress resource when enabled
     ```
 
 - Commit a version with a breaking change:
 
     ```
-    feat(core): Deprecate observer role from group memberships
+    feat: Deprecate network file system (NFS) options
 
-    BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+    BREAKING CHANGE: `nfs.enabled` key is no longer valid
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,3 +95,51 @@ These steps help emulate the existing GitHub Action that runs the `ct lint` comm
 - Name the running container as `ct`.
 - (Optional) Install all sub-chart dependencies with `ct`.
 - Run the `ct lint` command as it runs with the GitHub action specification.
+
+#### Commits and merges
+
+When squashing and merging to the `main` branch, use the following format to provide consistent updates to the `CHANGELOG.md` file:
+
+    <Commit Type>(scope): <Merge Description>
+
+- `Merge Description` should initiate with a capital letter, as it provides the changelog with a standard sentence structure.
+
+- `Scope` is used to define what is being updated. Our current scopes include:
+
+1. core
+3. grader
+4. workspace
+
+- `Commit Types` are listed below:
+
+| Commit Type | Commit Format |
+| --- | --- |
+| Chores | `chore` |
+| Documentation | `docs` |
+| Features | `feat` |
+| Fixes | `fix` |
+| Refactoring | `refactor` |
+
+Use the `BREAKING CHANGE` in the commit's footer if a release has a breaking change.
+
+Examples:
+
+- Commit a new feature:
+
+    ```
+    feat(workspace): Publish static notebooks with live widgets
+    ```
+
+- Commit a bug fix:
+
+    ```
+    fix(core): Allow students to open submitted assignments from grades section
+    ```
+
+- Commit a version with a breaking change:
+
+    ```
+    feat(core): Deprecate observer role from group memberships
+
+    BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+    ```


### PR DESCRIPTION
Updates the Contribution guide to clarify the steps used to run `ct lint ...` locally.