### PR TITLE
removes toleration for efs csi driver

### DIFF
--- a/charts/cluster/Chart.yaml
+++ b/charts/cluster/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cluster
-version: 0.0.1
-appVersion: 0.0.1
-description: Fes
+version: 0.0.2
+appVersion: 0.0.2
+description: Cluster based resources that the Illumidesk stack may need
 maintainers:
   - name: IllumiDesk Team
     email: hello@illumidesk.com

--- a/charts/cluster/templates/efs_csi_driver.yaml
+++ b/charts/cluster/templates/efs_csi_driver.yaml
@@ -301,8 +301,6 @@ spec:
         beta.kubernetes.io/os: linux
       priorityClassName: system-node-critical
       serviceAccountName: efs-csi-node-sa
-      tolerations:
-      - operator: Exists
       volumes:
       - hostPath:
           path: /var/lib/kubelet


### PR DESCRIPTION
removes toleration `op=Exists` so that efs csi driver can be deployed to node instead of fargate. 